### PR TITLE
Update the definition of the flush callback function

### DIFF
--- a/out_stdout2/stdout2.c
+++ b/out_stdout2/stdout2.c
@@ -30,13 +30,13 @@ static int cb_stdout_init(struct flb_output_instance *ins,
     (void) data;
 }
 
-static void cb_stdout_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
+static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)
 {
-    flb_pack_print(data, bytes);
+    flb_pack_print(event_chunk->data, event_chunk->size);
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 


### PR DESCRIPTION
Update the definition of the `cb_stdout_flush function` to be consistent with the latest version of fluent-bit source code.
https://github.com/fluent/fluent-bit/blob/master/include/fluent-bit/flb_output.h#L196