### PR TITLE
out_stdout2: fix function args to support fluent-bit v2

### DIFF
--- a/out_stdout2/stdout2.c
+++ b/out_stdout2/stdout2.c
@@ -30,13 +30,13 @@ static int cb_stdout_init(struct flb_output_instance *ins,
     (void) data;
 }
 
-static void cb_stdout_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
+static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)
 {
-    flb_pack_print(data, bytes);
+    flb_pack_print(event_chunk->data, event_chunk->size);
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 


### PR DESCRIPTION
Current code uses old function prototypes.
It causes following build warning and sigsegv.

This patch is to support fluent-bit v2 prototypes.
https://github.com/fluent/fluent-bit/blob/v2.0.6/include/fluent-bit/flb_output.h#L199

Warning:
```
[ 50%] Building C object out_stdout2/CMakeFiles/flb-out_stdout2.dir/stdout2.c.o
/home/taka/git/fluent-bit-plugin/out_stdout2/stdout2.c:52:21: warning: initialization of ‘void (*)(struct flb_event_chunk *, struct flb_output_flush *, struct flb_input_instance *, void *, struct flb_config *)’ from incompatible pointer type ‘void (*)(const void *, size_t,  const char *, int,  struct flb_input_instance *, void *, struct flb_config *)’ {aka ‘void (*)(const void *, long unsigned int,  const char *, int,  struct flb_input_instance *, void *, struct flb_config *)’} [-Wincompatible-pointer-types]
   52 |     .cb_flush     = cb_stdout_flush,
      |                     ^~~~~~~~~~~~~~~
```

SIGSEGV:
```
[2022/12/10 08:06:36] [engine] caught signal (SIGSEGV)
#0  0x561068dc8dc1      in  msgpack_object_bin_print() at lib/msgpack-c/src/objectc.c:134
#1  0x561068dc8fee      in  msgpack_object_print() at lib/msgpack-c/src/objectc.c:192
#2  0x5610682ff8c1      in  flb_pack_print() at src/flb_pack.c:472
#3  0x7ff2d86b0d38      in  ???() at ???:0
#4  0x561068321726      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:527
#5  0x561068de918a      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
#6  0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)
```